### PR TITLE
Add auto survey srv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,15 @@ find_package(tf2 REQUIRED)
 find_package(tf2_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "srv/AutoSurvey.srv"
+  DEPENDENCIES std_msgs
+)
+
+ament_export_dependencies(rosidl_default_runtime)
+
 
 include_directories(
   include 
@@ -29,14 +38,18 @@ set(ament_dependencies
   tf2_msgs
   tf2_ros
   tf2_geometry_msgs
-)
-link_directories("/usr/local/lib/")
+  )
+  link_directories("/usr/local/lib/")
 include_directories("/usr/local/include/")
 
 add_executable(duro_node src/duro_node.cpp src/utm.cpp src/fake_orientation.cpp)
 
 ament_target_dependencies(duro_node ${ament_dependencies})
 target_link_libraries(duro_node sbp)
+
+rosidl_target_interfaces(duro_node
+  ${PROJECT_NAME} "rosidl_typesupport_cpp"
+)
 
 ## Install
 ## Mark executables and/or libraries for installation

--- a/package.xml
+++ b/package.xml
@@ -23,6 +23,12 @@
   <depend>tf2_ros</depend>
   <depend>tf2_geometry_msgs</depend>
 
+  <build_depend>rosidl_default_generators</build_depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/srv/AutoSurvey.srv
+++ b/srv/AutoSurvey.srv
@@ -1,0 +1,5 @@
+---
+float64 latitude
+float64 longitude
+float64 altitude
+int32 write_status


### PR DESCRIPTION
#### **Overview**

This PR adds a ros2 service to perform the auto survey of the Duro GNSS. The service sets the surveyed position as the mean of the last N readings of latitude, longitude, and altitude, where N is the input of the service. In addition, it saves these values in the long-term memory of the Duro device.

#### **Use the following settings in the overrides file for docker testing**

- _overrides.yaml_

  ```yaml
    overrides:
      - duro_gps_driver:
        branch: feature/auto_survey_srv
  ```

- _manifest_

  ```yaml
    layout:
      - duro_gps_driver
  ```

#### **What was added/changed in this update**

[Add auto survey srv](https://github.com/Brazilian-Institute-of-Robotics/duro_gps_driver/commit/eb0d5cb6a4c7ca78fbf1c5ad9a0bb690691953a1)

#### **Depends On:**

#### **Related Issues:**

#### **Notes:**

N/A.